### PR TITLE
Fix `Base.show` method for `RepeatingDecimal`

### DIFF
--- a/src/_RepeatingDecimal.jl
+++ b/src/_RepeatingDecimal.jl
@@ -42,7 +42,9 @@ function Base.show(io::IO, rd::RepeatingDecimal)
     period = rd.period
 
     integer_str = string(finite_part)[begin:end-point_position]
-    finite_decimal_str = string(finite_part)[end-point_position+1:end]
+    integer_str = integer_str=="" ? "0" : integer_str
+    finite_decimal_str = string(finite_part)[max(end-point_position+1,1):end]
+    finite_decimal_str = lpad(finite_decimal_str, point_position, '0')
     sign_str = sign ? "+" : "-"
 
     digits_str = "$point_position|"*'-'^point_position*'|'*'-'^period*"|$period"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,50 @@ end
     @test rationalify("0.1(6)") === 1//6
 end
 
+@testset "RepeatingDecimal" begin
+    @testset "show" begin
+        rd = RepeatingDecimal("14.5(64)")
+        @test string(rd)*"\n" == """
+                1|-|--|2
+              +14.5(64)
+        ----------- --------------
+        Finite part Repeating part
+        """
+
+        rd = RepeatingDecimal("0.00145(64)")
+        @test string(rd)*"\n" == """
+            5|-----|--|2
+           +0.00145(64)
+        ----------- --------------
+        Finite part Repeating part
+        """
+
+        rd = RepeatingDecimal("0")
+        @test string(rd)*"\n" == """
+                0||-|1
+                +0.(0)
+        ----------- --------------
+        Finite part Repeating part
+        """
+
+        rd = RepeatingDecimal("0.001")
+        @test string(rd)*"\n" == """
+                3|---|-|1
+                +0.001(0)
+        ----------- --------------
+        Finite part Repeating part
+        """
+
+        rd = RepeatingDecimal(1//7)
+        @test string(rd)*"\n" == """
+                 0||------|6
+                +0.(142857)
+        ----------- --------------
+        Finite part Repeating part
+        """
+    end
+end
+
 @testset "notations" begin
     @testset "ParenthesesNotation" begin
         no = ParenthesesNotation()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,7 +105,7 @@ end
 
         rd = RepeatingDecimal("0")
         @test string(rd)*"\n" == """
-                0||-|1
+                 0||-|1
                 +0.(0)
         ----------- --------------
         Finite part Repeating part
@@ -113,8 +113,8 @@ end
 
         rd = RepeatingDecimal("0.001")
         @test string(rd)*"\n" == """
-                3|---|-|1
-                +0.001(0)
+              3|---|-|1
+             +0.001(0)
         ----------- --------------
         Finite part Repeating part
         """


### PR DESCRIPTION
This PR fixes https://github.com/hyrodium/RepeatingDecimalNotations.jl/issues/7.

**Before this PR**

```julia
julia> using RepeatingDecimalNotations

julia> RepeatingDecimal("0.045(64)")
Error showing value of type RepeatingDecimal:
ERROR: BoundsError: attempt to access 2-codeunit String at index [0:2]
Stacktrace:
[...]
```

**After this PR**

```julia
julia> using RepeatingDecimalNotations

julia> RepeatingDecimal("0.045(64)")
      3|---|--|2
     +0.045(64)
----------- --------------
Finite part Repeating part
```