### PR TITLE
Drop support for `−` (U+2212, \minus)

### DIFF
--- a/src/_EllipsisNotation.jl
+++ b/src/_EllipsisNotation.jl
@@ -1,16 +1,14 @@
 struct EllipsisNotation <: RepeatingDecimalNotation end
 
-m = match(r"^(-|−?)(\d+)\.(\d*)(\d\d+)\4{1,}\.\.\.$", "-12.12341234...")
-
 function isvalidnotaiton(::EllipsisNotation, str::AbstractString)
     str = _remove_underscore(str)
-    m = match(r"^(\-|−?)(\d+)$", str)
+    m = match(r"^(\-?)(\d+)$", str)
     isnothing(m) || return true
-    m = match(r"^(\-|−?)(\d*)\.(\d+)$", str)
+    m = match(r"^(\-?)(\d*)\.(\d+)$", str)
     isnothing(m) || return true
-    m = match(r"^(\-|−?)(\d*)\.(\d*)(\d\d+)\4{1,}\.\.\.$", str)
+    m = match(r"^(\-?)(\d*)\.(\d*)(\d\d+)\4{1,}\.\.\.$", str)
     isnothing(m) || return true
-    m = match(r"^(\-|−?)(\d*)\.(\d*)(\d)\4{2,}\.\.\.$", str)
+    m = match(r"^(\-?)(\d*)\.(\d*)(\d)\4{2,}\.\.\.$", str)
     isnothing(m) || return true
     return false
 end
@@ -41,7 +39,7 @@ end
 
 function RepeatingDecimal(::EllipsisNotation, str::AbstractString)
     str = _remove_underscore(str)
-    m = match(r"^(\-|−?)(\d+)$", str)
+    m = match(r"^(\-?)(\d+)$", str)
     if !isnothing(m)
         # "-1234"
         sign_str, integer_str = m.captures
@@ -52,7 +50,7 @@ function RepeatingDecimal(::EllipsisNotation, str::AbstractString)
         sign = sign_str==""
         return RepeatingDecimal(sign, r_finite, r_repeat, point_position, period)
     end
-    m = match(r"^(\-|−?)(\d*)\.(\d+)$", str)
+    m = match(r"^(\-?)(\d*)\.(\d+)$", str)
     if !isnothing(m)
         # "-123.4"
         sign_str, integer_str, decimal_str = m.captures
@@ -63,7 +61,7 @@ function RepeatingDecimal(::EllipsisNotation, str::AbstractString)
         sign = sign_str==""
         return RepeatingDecimal(sign, r_finite, r_repeat, point_position, period)
     end
-    m = match(r"^(\-|−?)(\d*)\.(\d*)(\d\d+)\4{1,}\.\.\.$", str)
+    m = match(r"^(\-?)(\d*)\.(\d*)(\d\d+)\4{1,}\.\.\.$", str)
     if !isnothing(m)
         # "-123.45656..."
         sign_str, integer_str, decimal_str, repeat_str = m.captures
@@ -74,7 +72,7 @@ function RepeatingDecimal(::EllipsisNotation, str::AbstractString)
         sign = sign_str==""
         return RepeatingDecimal(sign, r_finite, r_repeat, point_position, period)
     end
-    m = match(r"^(\-|−?)(\d*)\.(\d*)(\d)\4{2,}\.\.\.$", str)
+    m = match(r"^(\-?)(\d*)\.(\d*)(\d)\4{2,}\.\.\.$", str)
     if !isnothing(m)
         # "-123.4333..."
         sign_str, integer_str, decimal_str, repeat_str = m.captures

--- a/src/_ParenthesesNotation.jl
+++ b/src/_ParenthesesNotation.jl
@@ -3,7 +3,7 @@ struct ParenthesesNotation <: RepeatingDecimalNotation end
 function isvalidnotaiton(::ParenthesesNotation, str::AbstractString)
     str = _remove_underscore(str)
     i = firstindex(str)
-    if str[i] == '-' || str[i] == '−'
+    if str[i] == '-'
         str = str[nextind(str, i):end]
     end
     if !isnothing(match(r"^\d+$", str))
@@ -56,7 +56,7 @@ function RepeatingDecimal(::ParenthesesNotation, str::AbstractString)
     str = _remove_underscore(str)
     i = firstindex(str)
     local sign
-    if str[i] == '-' || str[i] == '−'
+    if str[i] == '-'
         sign = false
         str = str[nextind(str, i):end]
     else

--- a/src/_ScientificNotation.jl
+++ b/src/_ScientificNotation.jl
@@ -3,7 +3,7 @@ struct ScientificNotation <: RepeatingDecimalNotation end
 function isvalidnotaiton(::ScientificNotation, _str::AbstractString)
     str = _remove_underscore(_str)
     i = firstindex(str)
-    if str[i] == '-' || str[i] == '−'
+    if str[i] == '-'
         str = str[nextind(str, i):end]
     end
     if !isnothing(match(r"^\d+$", str))
@@ -27,7 +27,7 @@ function isvalidnotaiton(::ScientificNotation, _str::AbstractString)
     elseif !isnothing(match(r"^\.r\d+$", str))
         # ".r45"
         return true
-    elseif !isnothing(match(r"^(\-|−?)(\d+)\.(\d+)r(\d+)e(-?\d)$", _str))
+    elseif !isnothing(match(r"^(\-?)(\d+)\.(\d+)r(\d+)e(-?\d)$", _str))
         return true
     else
         return false
@@ -58,7 +58,7 @@ function RepeatingDecimal(::ScientificNotation, _str::AbstractString)
     str = _remove_underscore(_str)
     i = firstindex(str)
     local sign
-    if str[i] == '-' || str[i] == '−'
+    if str[i] == '-'
         sign = false
         str = str[nextind(str, i):end]
     else
@@ -115,7 +115,7 @@ function RepeatingDecimal(::ScientificNotation, _str::AbstractString)
         r_repeating = parse(BigInt, repeating_part)
         return RepeatingDecimal(sign, big(0), r_repeating, 0, length(repeating_part))
     end
-    m = match(r"^(\-|−?)(\d+)\.(\d+)r(\d+)e(-?\d)$", _str)
+    m = match(r"^(\-?)(\d+)\.(\d+)r(\d+)e(-?\d)$", _str)
     if !isnothing(m)
         # 1.234r56e2
         sign_str, integer_str, decimal_str, repeat_str, exponet_str = m.captures

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,7 +7,7 @@ Aqua.test_all(RepeatingDecimalNotations)
 
 @testset "@rd_str macro" begin
     @test rd"1.0"    === 1//1
-    @test rd"−1"     === -1//1
+    @test rd"-1"     === -1//1
     @test rd".45"    === 45//100
 
     @testset "ParenthesesNotation" begin


### PR DESCRIPTION
This PR fixes #9.