### PR TITLE
Replace `\d` with `[0-9]`

### DIFF
--- a/src/_DotsNotation.jl
+++ b/src/_DotsNotation.jl
@@ -20,10 +20,10 @@ struct DotsNotation <: RepeatingDecimalNotation end
 
 function isvalidnotaiton(::DotsNotation, str::AbstractString)
     str = _remove_underscore(str)
-    isnothing(match(r"^(\-|−|\+?)(\d+)\.?$", str))                || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d+)$", str))            || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d*)(\d)̇(\d+)̇$", str))   || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d*)(\d)̇$", str))        || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]+)\.?$", str))                       || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]+)$", str))                || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9])̇([0-9]+)̇$", str)) || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9])̇$", str))         || return true
     return false
 end
 
@@ -53,7 +53,7 @@ end
 
 function RepeatingDecimal(::DotsNotation, str::AbstractString)
     str = _remove_underscore(str)
-    m = match(r"^(\-|−|\+?)(\d+)\.?$", str)
+    m = match(r"^(\-|−|\+?)([0-9]+)\.?$", str)
     if !isnothing(m)
         # 123
         # 123.
@@ -66,7 +66,7 @@ function RepeatingDecimal(::DotsNotation, str::AbstractString)
         sign_str, integer_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, "", "0")
     end
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d+)$", str)
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]+)$", str)
     if !isnothing(m)
         # 123.45
         # .45
@@ -79,16 +79,16 @@ function RepeatingDecimal(::DotsNotation, str::AbstractString)
         sign_str, integer_str, decimal_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, decimal_str, "0")
     end
-    # ⋅⇒\dot r"^(\-|−|\+?)(\d*)\.(\d*)(\d)⋅(\d+)⋅$"
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d*)(\d)̇(\d+)̇$", str)
+    # ⋅⇒\dot r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9])⋅([0-9]+)⋅$"
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9])̇([0-9]+)̇$", str)
     if !isnothing(m)
         # 1.2345̇6̇
         # 1.2̇3̇
         sign_str, integer_str, decimal_str, repeat_str1, repeat_str2 = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, decimal_str, repeat_str1 * repeat_str2)
     end
-    # ⋅⇒\dot r"^(\-|−|\+?)(\d*)\.(\d*)(\d)⋅$"
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d*)(\d)̇$", str)
+    # ⋅⇒\dot r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9])⋅$"
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9])̇$", str)
     if !isnothing(m)
         # 1.2345̇
         # 1.2̇

--- a/src/_EllipsisNotation.jl
+++ b/src/_EllipsisNotation.jl
@@ -32,10 +32,10 @@ struct EllipsisNotation <: RepeatingDecimalNotation end
 
 function isvalidnotaiton(::EllipsisNotation, str::AbstractString)
     str = _remove_underscore(str)
-    isnothing(match(r"^(\-|−|\+?)(\d+)$", str))                           || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d+)$", str))                    || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d*)(\d\d+)\4{1,}\.\.\.$", str)) || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d*)(\d)\4{2,}\.\.\.$", str))    || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]+)$", str))                                    || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]+)$", str))                          || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9][0-9]+)\4{1,}\.\.\.$", str)) || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9])\4{2,}\.\.\.$", str))       || return true
     return false
 end
 
@@ -65,7 +65,7 @@ end
 
 function RepeatingDecimal(::EllipsisNotation, str::AbstractString)
     str = _remove_underscore(str)
-    m = match(r"^(\-|−|\+?)(\d+)\.?$", str)
+    m = match(r"^(\-|−|\+?)([0-9]+)\.?$", str)
     if !isnothing(m)
         # 123
         # 123.
@@ -78,7 +78,7 @@ function RepeatingDecimal(::EllipsisNotation, str::AbstractString)
         sign_str, integer_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, "", "0")
     end
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d+)$", str)
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]+)$", str)
     if !isnothing(m)
         # 123.45
         # .45
@@ -91,13 +91,13 @@ function RepeatingDecimal(::EllipsisNotation, str::AbstractString)
         sign_str, integer_str, decimal_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, decimal_str, "0")
     end
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d*)(\d\d+)\4{1,}\.\.\.$", str)
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9][0-9]+)\4{1,}\.\.\.$", str)
     if !isnothing(m)
         # "-123.45656..."
         sign_str, integer_str, decimal_str, repeat_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, decimal_str, repeat_str)
     end
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d*)(\d)\4{2,}\.\.\.$", str)
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)([0-9])\4{2,}\.\.\.$", str)
     if !isnothing(m)
         # "-123.4333..."
         sign_str, integer_str, decimal_str, repeat_str = m.captures

--- a/src/_ParenthesesNotation.jl
+++ b/src/_ParenthesesNotation.jl
@@ -20,9 +20,9 @@ struct ParenthesesNotation <: RepeatingDecimalNotation end
 
 function isvalidnotaiton(::ParenthesesNotation, str::AbstractString)
     str = _remove_underscore(str)
-    isnothing(match(r"^(\-|−|\+?)(\d+)\.?$", str))              || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d+)$", str))          || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d*)\((\d+)\)$", str)) || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]+)\.?$", str))                    || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]+)$", str))             || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)\(([0-9]+)\)$", str)) || return true
     return false
 end
 
@@ -48,7 +48,7 @@ end
 
 function RepeatingDecimal(::ParenthesesNotation, str::AbstractString)
     str = _remove_underscore(str)
-    m = match(r"^(\-|−|\+?)(\d+)\.?$", str)
+    m = match(r"^(\-|−|\+?)([0-9]+)\.?$", str)
     if !isnothing(m)
         # 123
         # 123.
@@ -61,7 +61,7 @@ function RepeatingDecimal(::ParenthesesNotation, str::AbstractString)
         sign_str, integer_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, "", "0")
     end
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d+)$", str)
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]+)$", str)
     if !isnothing(m)
         # 123.45
         # .45
@@ -74,7 +74,7 @@ function RepeatingDecimal(::ParenthesesNotation, str::AbstractString)
         sign_str, integer_str, decimal_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, decimal_str, "0")
     end
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d*)\((\d+)\)$", str)
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)\(([0-9]+)\)$", str)
     if !isnothing(m)
         # 1.234(56)
         # 1.(23)

--- a/src/_ScientificNotation.jl
+++ b/src/_ScientificNotation.jl
@@ -23,13 +23,13 @@ struct ScientificNotation <: RepeatingDecimalNotation end
 
 function isvalidnotaiton(::ScientificNotation, str::AbstractString)
     str = _remove_underscore(str)
-    isnothing(match(r"^(\-|−|\+?)(\d+)\.?$", str))                        || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d+)$", str))                    || return true
-    isnothing(match(r"^(\-|−|\+?)(\d+)\.(\d*)r(\d+)$", str))              || return true
-    isnothing(match(r"^(\-|−|\+?)\.(\d*)r(\d+)$", str))                   || return true
-    isnothing(match(r"^(\-|−|\+?)(\d+)\.(\d*)e((\-|−|\+)?\d+)$", str))       || return true
-    isnothing(match(r"^(\-|−|\+?)\.(\d+)e((\-|−|\+)?\d+)$", str))            || return true
-    isnothing(match(r"^(\-|−|\+?)(\d*)\.(\d*)r(\d+)e((\-|−|\+)?\d+)$", str)) || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]+)\.?$", str))                                    || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]+)$", str))                             || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]+)\.([0-9]*)r([0-9]+)$", str))                    || return true
+    isnothing(match(r"^(\-|−|\+?)\.([0-9]*)r([0-9]+)$", str))                            || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]+)\.([0-9]*)e((\-|−|\+)?[0-9]+)$", str))          || return true
+    isnothing(match(r"^(\-|−|\+?)\.([0-9]+)e((\-|−|\+)?[0-9]+)$", str))                  || return true
+    isnothing(match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)r([0-9]+)e((\-|−|\+)?[0-9]+)$", str)) || return true
     return false
 end
 
@@ -55,7 +55,7 @@ end
 
 function RepeatingDecimal(::ScientificNotation, str::AbstractString)
     str = _remove_underscore(str)
-    m = match(r"^(\-|−|\+?)(\d+)\.?$", str)
+    m = match(r"^(\-|−|\+?)([0-9]+)\.?$", str)
     if !isnothing(m)
         # 123
         # 123.
@@ -68,7 +68,7 @@ function RepeatingDecimal(::ScientificNotation, str::AbstractString)
         sign_str, integer_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, "", "0")
     end
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d+)$", str)
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]+)$", str)
     if !isnothing(m)
         # 123.45
         # .45
@@ -81,34 +81,34 @@ function RepeatingDecimal(::ScientificNotation, str::AbstractString)
         sign_str, integer_str, decimal_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, decimal_str, "0")
     end
-    m = match(r"^(\-|−|\+?)(\d+)\.(\d*)r(\d+)$", str)
+    m = match(r"^(\-|−|\+?)([0-9]+)\.([0-9]*)r([0-9]+)$", str)
     if !isnothing(m)
         # 1.234r56
         # 1.r23
         sign_str, integer_str, decimal_str, repeat_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, decimal_str, repeat_str)
     end
-    m = match(r"^(\-|−|\+?)\.(\d*)r(\d+)$", str)
+    m = match(r"^(\-|−|\+?)\.([0-9]*)r([0-9]+)$", str)
     if !isnothing(m)
         # .234r56
         # .r123
         sign_str, decimal_str, repeat_str = m.captures
         return _repeating_decimal_from_strings(sign_str, "", decimal_str, repeat_str)
     end
-    m = match(r"^(\-|−|\+?)(\d+)\.(\d*)e((\-|−|\+)?\d+)$", str)
+    m = match(r"^(\-|−|\+?)([0-9]+)\.([0-9]*)e((\-|−|\+)?[0-9]+)$", str)
     if !isnothing(m)
         # 1.234e56
         # 1.e23
         sign_str, integer_str, decimal_str, exponent_str = m.captures
         return _repeating_decimal_from_strings(sign_str, integer_str, decimal_str, "0", exponent_str)
     end
-    m = match(r"^(\-|−|\+?)\.(\d+)e((\-|−|\+)?\d+)$", str)
+    m = match(r"^(\-|−|\+?)\.([0-9]+)e((\-|−|\+)?[0-9]+)$", str)
     if !isnothing(m)
         # .234e56
         sign_str, decimal_str, exponent_str = m.captures
         return _repeating_decimal_from_strings(sign_str, "", decimal_str, "0", exponent_str)
     end
-    m = match(r"^(\-|−|\+?)(\d*)\.(\d*)r(\d+)e((\-|−|\+)?\d+)$", str)
+    m = match(r"^(\-|−|\+?)([0-9]*)\.([0-9]*)r([0-9]+)e((\-|−|\+)?[0-9]+)$", str)
     if !isnothing(m)
         # 1.234r56e2
         # 1.r23e2

--- a/src/_util.jl
+++ b/src/_util.jl
@@ -1,6 +1,6 @@
 function _remove_underscore(str::AbstractString)
-    str = replace(str, r"(\d)_(\d)" => s"\1\2")
-    str = replace(str, r"(\d)_(\d)" => s"\1\2")
+    str = replace(str, r"([0-9])_([0-9])" => s"\1\2")
+    str = replace(str, r"([0-9])_([0-9])" => s"\1\2")
     return str
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,25 +197,24 @@ end
 
     @testset "invalid non-repeating decimal" begin
         @testset for no in (ParenthesesNotation(), DotsNotation(), ScientificNotation(), EllipsisNotation())
-            @testset "invalid repeating decimal" begin
-                @testset for str in [
-                    "123.4.5"
-                    "++1235"
-                    "12__3"
-                    "1_2_3_"
-                    "_1_2_3"
-                    "1_2._3"
-                    "1_2_.3"
-                    " 123"
-                    " 123 "
-                    "..45"
-                    "-+123.45"
-                    "-."
-                    "−−123.45"
-                ]
-                    @test_throws ErrorException RepeatingDecimal(str)
-                    @test_throws ErrorException RepeatingDecimal(no, str)
-                end
+            @testset for str in [
+                "123.4.5"
+                "++1235"
+                "12__3"
+                "1_2_3_"
+                "_1_2_3"
+                "1_2._3"
+                "1_2_.3"
+                " 123"
+                " 123 "
+                "..45"
+                "-+123.45"
+                "-."
+                "−−123.45"
+                "４２"
+            ]
+                @test_throws ErrorException RepeatingDecimal(str)
+                @test_throws ErrorException RepeatingDecimal(no, str)
             end
         end
     end
@@ -256,6 +255,7 @@ end
                 "12.453)"
                 "12(.)453"
                 "()12453"
+                "４２.(４２)"
             ]
                 @test_throws ErrorException RepeatingDecimal(str)
                 @test_throws ErrorException RepeatingDecimal(no, str)
@@ -299,6 +299,7 @@ end
                 "12.453̇_"
                 "12̇.453"
                 "1̇2453̇"
+                "４２.4̇4̇"
             ]
                 @test_throws ErrorException RepeatingDecimal(str)
                 @test_throws ErrorException RepeatingDecimal(no, str)
@@ -343,6 +344,7 @@ end
                 "12.453r_"
                 "12r.453"
                 "r12453"
+                "４２.r42"
             ]
                 @test_throws ErrorException RepeatingDecimal(str)
                 @test_throws ErrorException RepeatingDecimal(no, str)
@@ -405,6 +407,7 @@ end
                 "12.453_..."
                 "12.453_453...."
                 "12.4.5353..."
+                "４２.4242..."
             ]
                 @test_throws ErrorException RepeatingDecimal(str)
                 @test_throws ErrorException RepeatingDecimal(no, str)


### PR DESCRIPTION
**Before this PR**
```julia
julia> using RepeatingDecimalNotations

julia> rd"３"
ERROR: LoadError: ArgumentError: invalid BigInt: "0３"
Stacktrace:
 [1] tryparse_internal(::Type{BigInt}, s::String, startpos::Int64, endpos::Int64, base_::Int64, raise::Bool)
   @ Base.GMP ./gmp.jl:306
 [2] #parse#619
   @ ./parse.jl:254 [inlined]
 [3] parse
   @ ./parse.jl:253 [inlined]
 [4] _repeating_decimal_from_strings(sign_str::SubString{String}, integer_str::SubString{String}, decimal_str::String, repeat_str::String)
   @ RepeatingDecimalNotations ~/.julia/dev/RepeatingDecimalNotations/src/_util.jl:19
 [5] RepeatingDecimal(::ParenthesesNotation, str::String)
   @ RepeatingDecimalNotations ~/.julia/dev/RepeatingDecimalNotations/src/_ParenthesesNotation.jl:62
 [6] RepeatingDecimal(str::String)
   @ RepeatingDecimalNotations ~/.julia/dev/RepeatingDecimalNotations/src/_RepeatingDecimal.jl:123
 [7] var"@rd_str"(__source__::LineNumberNode, __module__::Module, str::Any)
   @ RepeatingDecimalNotations ~/.julia/dev/RepeatingDecimalNotations/src/RepeatingDecimalNotations.jl:50
in expression starting at REPL[2]:1
```

**After this PR**
```julia
julia> using RepeatingDecimalNotations

julia> rd"３"
ERROR: LoadError: input string ３ is not valid!
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] RepeatingDecimal(str::String)
   @ RepeatingDecimalNotations ~/.julia/dev/RepeatingDecimalNotations/src/_RepeatingDecimal.jl:126
 [3] var"@rd_str"(__source__::LineNumberNode, __module__::Module, str::Any)
   @ RepeatingDecimalNotations ~/.julia/dev/RepeatingDecimalNotations/src/RepeatingDecimalNotations.jl:50
in expression starting at REPL[2]:1
```
