### PR TITLE
Bump version to `v1.0.0`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RepeatingDecimalNotations"
 uuid = "fbb887af-2519-40af-8dc5-25186fd85022"
 authors = ["hyrodium <hyrodium@gmail.com>"]
-version = "0.1.3"
+version = "1.0.0"
 
 [compat]
 Aqua = "0.8"


### PR DESCRIPTION
The API is quite stable, so let's release v1.0.0!
Note that there are no breaking changes with v1.0.0.